### PR TITLE
Fix a bug when activating netlink

### DIFF
--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -28,6 +28,7 @@
 #include "stdio-util.h"
 #include "string-table.h"
 #include "strv.h"
+#include "sysctl-util.h"
 #include "tmpfile-util.h"
 #include "util.h"
 #include "virt.h"
@@ -1890,6 +1891,8 @@ static int link_up(Link *link) {
         }
 
         if (link_ipv6_enabled(link)) {
+                uint8_t ipv6ll_mode;
+
                 r = sd_netlink_message_open_container(req, IFLA_AF_SPEC);
                 if (r < 0)
                         return log_link_error_errno(link, r, "Could not open IFLA_AF_SPEC container: %m");
@@ -1904,6 +1907,19 @@ static int link_up(Link *link) {
                         if (r < 0)
                                 return log_link_error_errno(link, r, "Could not append IFLA_INET6_TOKEN: %m");
                 }
+
+                if (!link_ipv6ll_enabled(link))
+                        ipv6ll_mode = IN6_ADDR_GEN_MODE_NONE;
+                else if (sysctl_read_ip_property(AF_INET6, link->ifname, "stable_secret", NULL) < 0)
+                        /* The file may not exist. And event if it exists, when stable_secret is unset,
+                         * reading the file fails with EIO. */
+                        ipv6ll_mode = IN6_ADDR_GEN_MODE_EUI64;
+                else
+                        ipv6ll_mode = IN6_ADDR_GEN_MODE_STABLE_PRIVACY;
+
+                r = sd_netlink_message_append_u8(req, IFLA_INET6_ADDR_GEN_MODE, ipv6ll_mode);
+                if (r < 0)
+                        return log_link_error_errno(link, r, "Could not append IFLA_INET6_ADDR_GEN_MODE: %m");
 
                 r = sd_netlink_message_close_container(req);
                 if (r < 0)

--- a/src/shared/sysctl-util.c
+++ b/src/shared/sysctl-util.c
@@ -69,3 +69,25 @@ int sysctl_read(const char *property, char **content) {
         p = strjoina("/proc/sys/", property);
         return read_full_file(p, content, NULL);
 }
+
+int sysctl_read_ip_property(int af, const char *ifname, const char *property, char **ret) {
+        _cleanup_free_ char *value = NULL;
+        const char *p;
+        int r;
+
+        assert(IN_SET(af, AF_INET, AF_INET6));
+        assert(property);
+
+        p = strjoina("/proc/sys/net/ipv", af == AF_INET ? "4" : "6",
+                     ifname ? "/conf/" : "", strempty(ifname),
+                     property[0] == '/' ? "" : "/", property);
+
+        r = read_one_line_file(p, &value);
+        if (r < 0)
+                return r;
+
+        if (ret)
+                *ret = TAKE_PTR(value);
+
+        return r;
+}

--- a/src/shared/sysctl-util.h
+++ b/src/shared/sysctl-util.h
@@ -5,3 +5,4 @@ char *sysctl_normalize(char *s);
 int sysctl_read(const char *property, char **value);
 int sysctl_write(const char *property, const char *value);
 
+int sysctl_read_ip_property(int af, const char *ifname, const char *property, char **ret);


### PR DESCRIPTION
Fix a bug in systemd not being able to activate netlink (like eth0) when booting with kernel 5.2.

See also https://github.com/systemd/systemd/issues/12504.