### PR TITLE
Revert "nspawn: remove unnecessary mount option parsing logic"

### DIFF
--- a/src/nspawn/nspawn-mount.c
+++ b/src/nspawn/nspawn-mount.c
@@ -661,14 +661,55 @@ int mount_all(const char *dest,
         return 0;
 }
 
+static int parse_mount_bind_options(const char *options, unsigned long *mount_flags, char **mount_opts) {
+        const char *p = options;
+        unsigned long flags = *mount_flags;
+        char *opts = NULL;
+        int r;
+
+        assert(options);
+
+        for (;;) {
+                _cleanup_free_ char *word = NULL;
+
+                r = extract_first_word(&p, &word, ",", 0);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to extract mount option: %m");
+                if (r == 0)
+                        break;
+
+                if (streq(word, "rbind"))
+                        flags |= MS_REC;
+                else if (streq(word, "norbind"))
+                        flags &= ~MS_REC;
+                else {
+                        log_error("Invalid bind mount option: %s", word);
+                        return -EINVAL;
+                }
+        }
+
+        *mount_flags = flags;
+        /* in the future mount_opts will hold string options for mount(2) */
+        *mount_opts = opts;
+
+        return 0;
+}
+
 static int mount_bind(const char *dest, CustomMount *m) {
 
-        _cleanup_free_ char *where = NULL;
+        _cleanup_free_ char *mount_opts = NULL, *where = NULL;
+        unsigned long mount_flags = MS_BIND | MS_REC;
         struct stat source_st, dest_st;
         int r;
 
         assert(dest);
         assert(m);
+
+        if (m->options) {
+                r = parse_mount_bind_options(m->options, &mount_flags, &mount_opts);
+                if (r < 0)
+                        return r;
+        }
 
         if (stat(m->source, &source_st) < 0)
                 return log_error_errno(errno, "Failed to stat %s: %m", m->source);
@@ -709,7 +750,7 @@ static int mount_bind(const char *dest, CustomMount *m) {
 
         }
 
-        r = mount_verbose(LOG_ERR, m->source, where, NULL, MS_BIND | MS_REC, m->options);
+        r = mount_verbose(LOG_ERR, m->source, where, NULL, mount_flags, mount_opts);
         if (r < 0)
                 return r;
 


### PR DESCRIPTION
Backport the upstream fix https://github.com/systemd/systemd/pull/13173 to the systemd v241 tree.

Original commit message:

====
This reverts commit [72d967df3e27186dd014bed2c6e7400cc32d84c5](https://github.com/systemd/systemd/commit/72d967df3e27186dd014bed2c6e7400cc32d84c5).

Revert this because it broke the `norbind` option of the bind flags
because it does bind-mounts unconditionally recursive.

Let's bring the old logic back.

Fixes: https://github.com/systemd/systemd/issues/13170