### PR TITLE
network: fix ListenPort= in [WireGuard] section

### DIFF
--- a/src/network/netdev/wireguard.c
+++ b/src/network/netdev/wireguard.c
@@ -453,22 +453,23 @@ int config_parse_wireguard_listen_port(
                 void *userdata) {
 
         uint16_t *s = data;
-        uint16_t port = 0;
         int r;
 
         assert(rvalue);
         assert(data);
 
-        if (!streq(rvalue, "auto")) {
-                r = parse_ip_port(rvalue, s);
-                if (r < 0) {
-                        log_syntax(unit, LOG_ERR, filename, line, r,
-                                   "Invalid port specification, ignoring assignment: %s", rvalue);
-                        return 0;
-                }
+        if (isempty(rvalue) || streq(rvalue, "auto")) {
+                *s = 0;
+                return 0;
         }
 
-        *s = port;
+        r = parse_ip_port(rvalue, s);
+        if (r < 0) {
+                log_syntax(unit, LOG_ERR, filename, line, r,
+                           "Invalid port specification, ignoring assignment: %s", rvalue);
+                return 0;
+        }
+
         return 0;
 }
 


### PR DESCRIPTION
Systemd-networkd v242 has a bug when parsing `ListenPort` for WireGuard.
Simply cherry-pick an upstream commit https://github.com/systemd/systemd/pull/12382/commits/a62b7bb79e9a2aa683624c32cde1c756d8466fb4.

The original commit message:
```
This fixes a bug introduced by https://github.com/systemd/systemd/commit/f1368a333e5e08575f0b45dfe41e936b106a8627.

Fixes https://github.com/systemd/systemd/issues/12377.
```

See also https://github.com/systemd/systemd/pull/12382,
https://lists.zx2c4.com/pipermail/wireguard/2019-September/004475.html
