### PR TITLE
sysctl.d/50-default.conf: remove *, .all source route settings

### DIFF
--- a/sysctl.d/50-default.conf
+++ b/sysctl.d/50-default.conf
@@ -23,27 +23,24 @@ kernel.core_uses_pid = 1
 
 # Source route verification
 net.ipv4.conf.default.rp_filter = 2
-# the below deviates from upstream systemd-245 (and later) since the default
-# rule causes a regression with cluster networking (e.g. cilium; see
-# https://github.com/flatcar-linux/Flatcar/issues/181)
+# We deviate from upstream systemd-245 (and later) since the new default
+# rp_filter wildcard rule causes a regression with cluster networking
+# (e.g. cilium; see https://github.com/flatcar-linux/Flatcar/issues/181)
 #net.ipv4.conf.*.rp_filter = 2
 #-net.ipv4.conf.all.rp_filter
 
 # Do not accept source routing
 net.ipv4.conf.default.accept_source_route = 0
-# the below deviates from upstream systemd-245 (and later) since the default
-# rule causes a regression with cluster networking (e.g. cilium; see
-# https://github.com/flatcar-linux/Flatcar/issues/181)
+# We deviate from upstream systemd-245 (and later) since the new default
+# source route wildcard rule causes a regression with cluster networking
+# (e.g. cilium; see https://github.com/flatcar-linux/Flatcar/issues/181)
 #net.ipv4.conf.*.accept_source_route = 0
 #-net.ipv4.conf.all.accept_source_route
 
 # Promote secondary addresses when the primary address is removed
 net.ipv4.conf.default.promote_secondaries = 1
-# the below deviates from upstream systemd-245 (and later) since the default
-# rule causes a regression with cluster networking (e.g. cilium; see
-# https://github.com/flatcar-linux/Flatcar/issues/181)
-#net.ipv4.conf.*.promote_secondaries = 1
-#-net.ipv4.conf.all.promote_secondaries
+net.ipv4.conf.*.promote_secondaries = 1
+-net.ipv4.conf.all.promote_secondaries
 
 # ping(8) without CAP_NET_ADMIN and CAP_NET_RAW
 # The upper limit is set to 2^31-1. Values greater than that get rejected by

--- a/sysctl.d/50-default.conf
+++ b/sysctl.d/50-default.conf
@@ -31,11 +31,8 @@ net.ipv4.conf.default.rp_filter = 2
 
 # Do not accept source routing
 net.ipv4.conf.default.accept_source_route = 0
-# We deviate from upstream systemd-245 (and later) since the new default
-# source route wildcard rule causes a regression with cluster networking
-# (e.g. cilium; see https://github.com/flatcar-linux/Flatcar/issues/181)
-#net.ipv4.conf.*.accept_source_route = 0
-#-net.ipv4.conf.all.accept_source_route
+net.ipv4.conf.*.accept_source_route = 0
+-net.ipv4.conf.all.accept_source_route
 
 # Promote secondary addresses when the primary address is removed
 net.ipv4.conf.default.promote_secondaries = 1

--- a/sysctl.d/50-default.conf
+++ b/sysctl.d/50-default.conf
@@ -23,18 +23,27 @@ kernel.core_uses_pid = 1
 
 # Source route verification
 net.ipv4.conf.default.rp_filter = 2
-net.ipv4.conf.*.rp_filter = 2
--net.ipv4.conf.all.rp_filter
+# the below deviates from upstream systemd-245 (and later) since the default
+# rule causes a regression with cluster networking (e.g. cilium; see
+# https://github.com/flatcar-linux/Flatcar/issues/181)
+#net.ipv4.conf.*.rp_filter = 2
+#-net.ipv4.conf.all.rp_filter
 
 # Do not accept source routing
 net.ipv4.conf.default.accept_source_route = 0
-net.ipv4.conf.*.accept_source_route = 0
--net.ipv4.conf.all.accept_source_route
+# the below deviates from upstream systemd-245 (and later) since the default
+# rule causes a regression with cluster networking (e.g. cilium; see
+# https://github.com/flatcar-linux/Flatcar/issues/181)
+#net.ipv4.conf.*.accept_source_route = 0
+#-net.ipv4.conf.all.accept_source_route
 
 # Promote secondary addresses when the primary address is removed
 net.ipv4.conf.default.promote_secondaries = 1
-net.ipv4.conf.*.promote_secondaries = 1
--net.ipv4.conf.all.promote_secondaries
+# the below deviates from upstream systemd-245 (and later) since the default
+# rule causes a regression with cluster networking (e.g. cilium; see
+# https://github.com/flatcar-linux/Flatcar/issues/181)
+#net.ipv4.conf.*.promote_secondaries = 1
+#-net.ipv4.conf.all.promote_secondaries
 
 # ping(8) without CAP_NET_ADMIN and CAP_NET_RAW
 # The upper limit is set to 2^31-1. Values greater than that get rejected by


### PR DESCRIPTION
# Remove wildcard, "all" source route settings from sysctl defaults

The rules were added in systemd-245 and break cluster networking, e.g. cilium. Please see https://github.com/flatcar-linux/Flatcar/issues/181 for details.

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>

### Also cherry-pick to `v246-flatcar` which has the same issue.
