### PR TITLE
Cherry-pick from v245-stable: Allow nameserver list to be emptied

### DIFF
--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -1155,6 +1155,12 @@ int config_parse_dns(
         assert(lvalue);
         assert(rvalue);
 
+        if (isempty(rvalue)) {
+                n->dns = mfree(n->dns);
+                n->n_dns = 0;
+                return 0;
+        }
+
         for (;;) {
                 _cleanup_free_ char *w = NULL;
                 union in_addr_union a;


### PR DESCRIPTION
This PR cherry-picks a [systemd-stable-v245 patch](https://github.com/systemd/systemd-stable/commit/25f1b107cd4ea5b00c919e6fe1cc68d119be2e1e) to fix a [systemd-networkd DNS parser bug](https://github.com/systemd/systemd/issues/16959) which was [reported to us](https://github.com/flatcar-linux/systemd/issues/10) recently.

The upstream patch is included in both 246 as well as 245-stable; however, no 245-stable release is available which includes this patch. Hence we cherry-pick.

Edit: **Note** this is the only change in upstream 245-stable after the 245.7 release currently shipped with Flatcar.

# Testing done:
1. compiled systemd locally with the beta-2605.3.0 SDK
2. started a qemu instance with the changes included
3. tested locally with qemu (on `eth0`) following instructions in the [upstream issue](https://github.com/systemd/systemd/issues/16959) and was able to override nameservers