### PR TITLE
Bring more patches to v246 from `v245-flatcar`

### DIFF
--- a/man/systemd-system.conf.xml
+++ b/man/systemd-system.conf.xml
@@ -361,8 +361,7 @@
         <listitem><para>Configure the default value for the per-unit <varname>TasksMax=</varname> setting. See
         <citerefentry><refentrytitle>systemd.resource-control</refentrytitle><manvolnum>5</manvolnum></citerefentry>
         for details. This setting applies to all unit types that support resource control settings, with the exception
-        of slice units. Defaults to 15%, which equals 4915 with the kernel's defaults on the host, but might be smaller
-        in OS containers.</para></listitem>
+        of slice units. Defaults to 100%.</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/man/systemd-update-done.service.xml
+++ b/man/systemd-update-done.service.xml
@@ -50,7 +50,7 @@
     <varname>ConditionNeedsUpdate=</varname> (see
     <citerefentry><refentrytitle>systemd.unit</refentrytitle><manvolnum>5</manvolnum></citerefentry>)
     condition to make sure to run when <filename>/etc</filename> or
-    <filename>/var</filename> are older than <filename>/usr</filename>
+    <filename>/var</filename> aren't the same age as <filename>/usr</filename>
     according to the modification times of the files described above.
     This requires that updates to <filename>/usr</filename> are always
     followed by an update of the modification time of

--- a/src/basic/cgroup-util.h
+++ b/src/basic/cgroup-util.h
@@ -129,6 +129,10 @@ static inline bool CGROUP_BLKIO_WEIGHT_IS_OK(uint64_t x) {
             (x >= CGROUP_BLKIO_WEIGHT_MIN && x <= CGROUP_BLKIO_WEIGHT_MAX);
 }
 
+/* Default resource limits */
+#define DEFAULT_TASKS_MAX_PERCENTAGE            100U /* 100% of PIDs */
+#define DEFAULT_USER_TASKS_MAX_PERCENTAGE       33U /* 33% of PIDs, 10813 on default settings */
+
 typedef enum CGroupUnified {
         CGROUP_UNIFIED_UNKNOWN = -1,
         CGROUP_UNIFIED_NONE = 0,        /* Both systemd and controllers on legacy */

--- a/src/core/selinux-access.c
+++ b/src/core/selinux-access.c
@@ -2,7 +2,7 @@
 
 #include "selinux-access.h"
 
-#if HAVE_SELINUX
+#if 0
 
 #include <errno.h>
 #include <selinux/avc.h>

--- a/src/core/system.conf.in
+++ b/src/core/system.conf.in
@@ -52,7 +52,7 @@
 #DefaultBlockIOAccounting=no
 #DefaultMemoryAccounting=@MEMORY_ACCOUNTING_DEFAULT@
 #DefaultTasksAccounting=yes
-#DefaultTasksMax=15%
+#DefaultTasksMax=100%
 #DefaultLimitCPU=
 #DefaultLimitFSIZE=
 #DefaultLimitDATA=

--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -461,6 +461,8 @@ int network_load_one(Manager *manager, OrderedHashmap **networks, const char *fi
 
                 .ipv4_accept_local = -1,
 
+                .ip_forward = _ADDRESS_FAMILY_INVALID,
+
                 .ipv6_privacy_extensions = IPV6_PRIVACY_EXTENSIONS_NO,
                 .ipv6_accept_ra = -1,
                 .ipv6_dad_transmits = -1,

--- a/src/network/wait-online/wait-online.c
+++ b/src/network/wait-online/wait-online.c
@@ -19,7 +19,7 @@ static usec_t arg_timeout = 120 * USEC_PER_SEC;
 static Hashmap *arg_interfaces = NULL;
 static char **arg_ignore = NULL;
 static LinkOperationalStateRange arg_required_operstate = { _LINK_OPERSTATE_INVALID, _LINK_OPERSTATE_INVALID };
-static bool arg_any = false;
+static bool arg_any = true;
 
 STATIC_DESTRUCTOR_REGISTER(arg_interfaces, hashmap_free_free_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_ignore, strv_freep);

--- a/src/shared/condition.c
+++ b/src/shared/condition.c
@@ -592,7 +592,7 @@ static int condition_test_needs_update(Condition *c, char **env) {
          * First, compare seconds as they are always accurate...
          */
         if (usr.st_mtim.tv_sec != other.st_mtim.tv_sec)
-                return usr.st_mtim.tv_sec > other.st_mtim.tv_sec;
+                return true;
 
         /*
          * ...then compare nanoseconds.
@@ -603,7 +603,7 @@ static int condition_test_needs_update(Condition *c, char **env) {
          * (otherwise the filesystem supports nsec timestamps, see stat(2)).
          */
         if (usr.st_mtim.tv_nsec == 0 || other.st_mtim.tv_nsec > 0)
-                return usr.st_mtim.tv_nsec > other.st_mtim.tv_nsec;
+                return usr.st_mtim.tv_nsec != other.st_mtim.tv_nsec;
 
         _cleanup_free_ char *timestamp_str = NULL;
         r = parse_env_file(NULL, p, "TIMESTAMP_NSEC", &timestamp_str);
@@ -622,7 +622,7 @@ static int condition_test_needs_update(Condition *c, char **env) {
                 return true;
         }
 
-        return timespec_load_nsec(&usr.st_mtim) > timestamp;
+        return timespec_load_nsec(&usr.st_mtim) != timestamp;
 }
 
 static int condition_test_first_boot(Condition *c, char **env) {


### PR DESCRIPTION
We have these patches in v245 too. I have missed them when doing the update to v246, because apparently I have assumed that our flatcar branches are more or less some upstream branch/tag + our patches on top. That assumption was wrong and it surfaced when I rebased the `v245-flatcar` branch to the `v245.8` tag.